### PR TITLE
Check to see if elements we're hiding/showing are already intentionally hidden.

### DIFF
--- a/js/jquery.reject.js
+++ b/js/jquery.reject.js
@@ -38,7 +38,7 @@ $.reject = function(opts) {
 		display: [], // What browsers to display and their order (default set below)
 		browserInfo: { // Settings for which browsers to display
 			firefox: {
-				text: 'Firefox 8', // Text below the icon
+				text: 'Firefox 12', // Text below the icon
 				url: 'http://www.mozilla.com/firefox/' // URL For icon/text link
 			},
 			safari: {
@@ -50,7 +50,7 @@ $.reject = function(opts) {
 				url: 'http://www.opera.com/download/'
 			},
 			chrome: {
-				text: 'Chrome 15',
+				text: 'Chrome 18',
 				url: 'http://www.google.com/chrome/'
 			},
 			msie: {


### PR DESCRIPTION
If I have a hidden <select> element (for an adaptive mobile menu, for example), jReject will show() this element, even though it's intentionally hidden.
