### PR TITLE
Removed the version number from Google Chrome and Mozilla Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Default Options:
 		browserShow: true, // Should the browser options be shown?
 		browserInfo: { // Settings for which browsers to display
 			firefox: {
-				text: 'Firefox 16', // Text below the icon
+				text: 'Mozilla Firefox', // Text below the icon
 				url: 'http://www.mozilla.com/firefox/' // URL For icon/text link
 			},
 			safari: {
@@ -52,7 +52,7 @@ Default Options:
 				url: 'http://www.opera.com/download/'
 			},
 			chrome: {
-				text: 'Chrome 23',
+				text: 'Google Chrome',
 				url: 'http://www.google.com/chrome/'
 			},
 			msie: {

--- a/js/jquery.reject.js
+++ b/js/jquery.reject.js
@@ -39,7 +39,7 @@ $.reject = function(options) {
 		browserShow: true, // Should the browser options be shown?
 		browserInfo: { // Settings for which browsers to display
 			firefox: {
-				text: 'Firefox 16', // Text below the icon
+				text: 'Mozilla Firefox', // Text below the icon
 				url: 'http://www.mozilla.com/firefox/' // URL For icon/text link
 			},
 			safari: {
@@ -51,7 +51,7 @@ $.reject = function(options) {
 				url: 'http://www.opera.com/download/'
 			},
 			chrome: {
-				text: 'Chrome 23',
+				text: 'Google Chrome',
 				url: 'http://www.google.com/chrome/'
 			},
 			msie: {


### PR DESCRIPTION
Because the new releases comes in short time, I just removed the versioning from Google Chrome and Mozilla Firefox
