### PR TITLE
It saves folks like me a lot of time to have the licensing info show up on the first page of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ Run On load (Default Options):
 	$(function() {
 		$.reject();
 	});
+
+Licensing:
+-----------------
+This library is dual licensed under the MIT and GPL licenses (as per jquery.reject.js).


### PR DESCRIPTION
Added license info to README.md

No worries if you don't want it there, but it's helpful for folks like me who need to know licensing is compatible before considering including a library in any projects.
