### PR TITLE
Fix layout when using with Bootstrap 3

### DIFF
--- a/css/jquery.reject.css
+++ b/css/jquery.reject.css
@@ -35,6 +35,7 @@
 	height: auto;
 	padding: 20px;
 	position: relative;
+	box-sizing: content-box;
 }
 
 #jr_header {


### PR DESCRIPTION
Ran into a problem with the layout of the modal dialog being messed up on my bootstrap 3 site. This resets the box-sizing to the default so it works correctly. Bootstrap 3 sets box-sizing to border-box.
