### PR TITLE
Allow blacklisting all versions older than a given number + Remove Chrome Frame

### DIFF
--- a/js/jquery.reject.js
+++ b/js/jquery.reject.js
@@ -12,7 +12,7 @@ $.reject = function(options) {
 	var opts = $.extend(true,{
 		reject : { // Rejection flags for specific browsers
 			all: false, // Covers Everything (Nothing blocked)
-			msie5: true, msie6: true // Covers MSIE 5-6 (Blocked by default)
+			msie: 6 // Covers MSIE <=6 (Blocked by default)
 			/*
 			 * Possibilities are endless...
 			 *
@@ -47,22 +47,16 @@ $.reject = function(options) {
 				url: 'http://www.google.com/chrome/'
 			},
 			safari: {
-				text: 'Safari 5',
+				text: 'Safari',
 				url: 'http://www.apple.com/safari/download/'
 			},
 			opera: {
-				text: 'Opera 12',
+				text: 'Opera',
 				url: 'http://www.opera.com/download/'
 			},
 			msie: {
-				text: 'Internet Explorer 9',
+				text: 'Internet Explorer',
 				url: 'http://www.microsoft.com/windows/Internet-explorer/'
-			},
-			gcf: {
-				text: 'Google Chrome Frame',
-				url: 'http://code.google.com/chrome/chromeframe/',
-				// This browser option will only be displayed for MSIE
-				allow: { all: false, msie: true }
 			}
 		},
 
@@ -112,7 +106,7 @@ $.reject = function(options) {
 
 	// Set default browsers to display if not already defined
 	if (opts.display.length < 1) {
-		opts.display = ['chrome','firefox','safari','opera','gcf','msie'];
+		opts.display = ['chrome','firefox','safari','opera','msie'];
 	}
 
 	// beforeRject: Customized Function
@@ -128,15 +122,17 @@ $.reject = function(options) {
 	// This function parses the advanced browser options
 	var browserCheck = function(settings) {
 		// Check 1: Look for 'all' forced setting
-		// Check 2: Operating System (eg. 'win','mac','linux','solaris','iphone')
-		// Check 3: Rendering engine (eg. 'webkit', 'gecko', 'trident')
-		// Check 4: Browser name (eg. 'firefox','msie','chrome')
-		// Check 5: Browser+major version (eg. 'firefox3','msie7','chrome4')
-		return (settings['all'] ? true : false) ||
-			(settings[$.os.name] ? true : false) ||
-			(settings[$.layout.name] ? true : false) ||
-			(settings[$.browser.name] ? true : false) ||
-			(settings[$.browser.className] ? true : false);
+		// Check 2: Browser+major version (optional) (eg. 'firefox','msie','{msie: 6}')
+		// Check 3: Browser+major version (eg. 'firefox3','msie7','chrome4')
+		// Check 4: Rendering engine+version (eg. 'webkit', 'gecko', '{webkit: 537.36}')
+		// Check 5: Operating System (eg. 'win','mac','linux','solaris','iphone')
+		var layout = settings[$.layout.name],
+			browser = settings[$.browser.name];
+		return !!(settings['all']
+			|| (browser && (browser === true || $.browser.versionNumber <= browser))
+			|| settings[$.browser.className]
+			|| (layout && (layout === true || $.layout.versionNumber <= layout))
+			|| settings[$.os.name]);
 	};
 
 	// Determine if we need to display rejection for this browser, or exit


### PR DESCRIPTION
I found it a little tedious to have to specify each individual revision, so I added in an option to specify a major revision number instead of `true` to blacklist anything older than the given number. So instead of

``` javascript
{msie5: true, msie6: true, msie7: true, msie8: true}
```

You can just do

``` javascript
{msie: 8}
```

It's still fully backwards compatible, however!

I also removed any mention of specific revisions for the modal since now that browsers update more often, it's probably going to be annoying to keep it up-to-date.

I also removed the option for Google Chrome Frame as they've retired it: http://blog.chromium.org/2013/06/retiring-chrome-frame.html
